### PR TITLE
Fix --exclude-uploads

### DIFF
--- a/src/classes/Command/Push.php
+++ b/src/classes/Command/Push.php
@@ -323,7 +323,7 @@ class Push extends Command {
 		$excludes = '';
 
 		if ( $exclude_uploads ) {
-			$excludes .= ' --exclude="./uploads/"';
+			$excludes .= ' --exclude="./uploads"';
 		}
 
 		exec( 'cd ' . escapeshellarg( WP_CONTENT_DIR ) . '/ && tar ' . $excludes . ' -zcf ../.wpsnapshots/files.tar.gz . > /dev/null' );


### PR DESCRIPTION
Remove trailing slashes at the end of excluded folders as it causes uploads folder not be excluded.