### PR TITLE
Fix S3 region and signature when creating a bucket.

### DIFF
--- a/src/classes/S3.php
+++ b/src/classes/S3.php
@@ -9,6 +9,7 @@ use WPSnapshots\Utils;
 class S3 {
 	private $client;
 	private $repository;
+	private $region;
 
 	/**
 	 * Setup S3 client
@@ -21,9 +22,12 @@ class S3 {
 				'key'    => $config['access_key_id'],
 				'secret' => $config['secret_access_key'],
 			],
+            'signature' => 'v4',
+            'region' => $config['region']
 		] );
 
 		$this->repository = $config['repository'];
+		$this->region = $config['region'];
 	}
 
 	/**
@@ -218,7 +222,7 @@ class S3 {
 		}
 
 		try {
-			$result = $this->client->createBucket( [ 'Bucket' => self::getBucketName( $this->repository ) ] );
+			$result = $this->client->createBucket( [ 'Bucket' => self::getBucketName( $this->repository ), 'LocationConstraint' => $this->region ] );
 		} catch ( \Exception $e ) {
 			$error = [
 				'message'        => $e->getMessage(),


### PR DESCRIPTION
Added support for creating a S3 bucket in a (newer) region other than us-west-1. Also added support for Signature Version 4 (default version 2 isn't supported in newer regions).