### PR TITLE
Change from &> to 2>&1. &> is a bash shortcut for the other, but not …

### DIFF
--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -423,7 +423,7 @@ class Pull extends Command {
 				/**
 				 * We suppress the error message because wp-content/ might already exist
 				 */
-				exec( 'mv ' . Utils\escape_shell_path( $path ) . 'wordpress/* . &> /dev/null' );
+				exec( 'mv ' . Utils\escape_shell_path( $path ) . 'wordpress/* . 2>&1 /dev/null' );
 
 				if ( $verbose ) {
 					$output->writeln( 'Removing temporary WordPress files...' );


### PR DESCRIPTION
…running bash with shell_exec so sometimes still see the errors