### PR TITLE
Improve hosts file suggestion 

### DIFF
--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -771,7 +771,7 @@ define('BLOG_ID_CURRENT_SITE', " . ( ( ! empty( $snapshot->meta['blog_id_current
 		Log::instance()->write( 'Visit in your browser: ' . $first_home_url, 0, 'success' );
 
 		if ( 'localhost' !== parse_url( $first_home_url, PHP_URL_HOST ) ) {
-			Log::instance()->write( 'Make sure the following entry is in your hosts file: ' . parse_url( $first_home_url, PHP_URL_HOST ) . ' 127.0.0.1', 0, 'success' );
+			Log::instance()->write( 'Make sure the following entry is in your hosts file: "127.0.0.1 ' . parse_url( $first_home_url, PHP_URL_HOST ) . '"', 0, 'success' );
 		}
 
 		Log::instance()->write( 'Admin login: username - "wpsnapshots", password - "password"', 0, 'success' );


### PR DESCRIPTION
This PR adjusts the host file suggestion to use:
IP_ADDRESS HOST instead of HOST IP_ADDRESS which is incorrect.

and wraps the suggestion in quotes to make it a little easier to read/separate visually.

### Before
`Make sure the following entry is in your hosts file: testsite.com 127.0.0.1`

### After
`Make sure the following entry is in your hosts file: "127.0.0.1 testsite.com"`

