### PR TITLE
dump database using a single transaction

### DIFF
--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -233,7 +233,7 @@ class Snapshot {
 		/**
 		 * Dump sql to .wpsnapshots/data.sql
 		 */
-		$command          = '/usr/bin/env mysqldump --single-transaction --no-defaults %s';
+		$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
 		$command_esc_args = array( DB_NAME );
 		$command         .= ' --tables';
 
@@ -274,7 +274,7 @@ class Snapshot {
 		Utils\run_mysql_command( $escaped_command, $mysql_args );
 
 		if ( ! $args['no_scrub'] ) {
-			$command = '/usr/bin/env mysqldump --single-transaction --no-defaults %s';
+			$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
 
 			$command_esc_args = array( DB_NAME );
 

--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -233,7 +233,7 @@ class Snapshot {
 		/**
 		 * Dump sql to .wpsnapshots/data.sql
 		 */
-		$command          = '/usr/bin/env mysqldump --no-defaults %s';
+		$command          = '/usr/bin/env mysqldump --single-transaction --no-defaults %s';
 		$command_esc_args = array( DB_NAME );
 		$command         .= ' --tables';
 
@@ -274,7 +274,7 @@ class Snapshot {
 		Utils\run_mysql_command( $escaped_command, $mysql_args );
 
 		if ( ! $args['no_scrub'] ) {
-			$command = '/usr/bin/env mysqldump --no-defaults %s';
+			$command = '/usr/bin/env mysqldump --single-transaction --no-defaults %s';
 
 			$command_esc_args = array( DB_NAME );
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

For larger databases that are in use it is important to perform the mysqldump using a single, global transaction to ensure consistency and also ensure you don't lock the database during the backup which will hang busy sites.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

This will allow large, busy databases to get snapshotted while in use.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I did a very basic check of running a create to ensure I still got a database backup file

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

No issue was created for this

### Changelog Entry

Use `--single-transaction` during the database backup phase of a create or push
