### PR TITLE
Disable client side monitoring

### DIFF
--- a/src/classes/DB.php
+++ b/src/classes/DB.php
@@ -72,6 +72,7 @@ class DB {
 				],
 				'region'      => $region,
 				'version'     => '2012-08-10',
+				'csm'         => false,
 			]
 		);
 	}

--- a/src/classes/S3.php
+++ b/src/classes/S3.php
@@ -73,6 +73,7 @@ class S3 {
 				'signature'   => 'v4',
 				'region'      => $region,
 				'version'     => '2006-03-01',
+				'csm'         => false,
 			]
 		);
 	}


### PR DESCRIPTION
### Description of the Change

Disables Client Side Monitoring.  Support for CSM Configuration was added to the AWS SDK in https://github.com/aws/aws-sdk-php/pull/1834.  Recently our users have been getting the following errors when attempting to push snapshots:

`Error Message: CSM 'port' value must be an integer!`

This pull requests disables CSM as per the AWS SDK spec.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
I'm not exactly sure what Client Side Monitoring does, so disabling it might have unintended affects.

### Verification Process

Testing in progress

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

- Disables AWS Client Side Monitoring
