### PR TITLE
Use the correct user table names when on multisite

### DIFF
--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -568,7 +568,15 @@ class Snapshot {
 
 						$dummy_user = $dummy_users[ $user_id % 1000 ];
 
-						$wpdb->query( "UPDATE {$wpdb->users}_temp SET user_pass='{$password}', user_email='{$dummy_user['email']}', user_url='', user_activation_key='', display_name='{$user['user_login']}' WHERE ID='{$user['ID']}'" );
+						$wpdb->query(
+							$wpdb->prepare(
+								"UPDATE {$wpdb->users}_temp SET user_pass=%s, user_email=%s, user_url='', user_activation_key='', display_name=%s WHERE ID=%d",
+								$password,
+								$dummy_user['email'],
+								$user['user_login'],
+								$user['ID']
+							)
+						);
 					}
 
 					$offset += 1000;

--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -395,7 +395,7 @@ class Snapshot {
 			/**
 			 * Dump sql to .wpsnapshots/data.sql
 			 */
-			$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
+			$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
 			$command_esc_args = array( DB_NAME );
 			$command         .= ' --tables';
 
@@ -408,11 +408,11 @@ class Snapshot {
 
 			foreach ( $tables as $table ) {
 				// We separate the users/meta table for scrubbing
-				if ( 0 < $args['scrub'] && $GLOBALS['table_prefix'] . 'users' === $table ) {
+				if ( 0 < $args['scrub'] && $wpdb->users === $table ) {
 					continue;
 				}
 
-				if ( 2 === $args['scrub'] && $GLOBALS['table_prefix'] . 'usermeta' === $table ) {
+				if ( 2 === $args['scrub'] && $wpdb->usermeta === $table ) {
 					continue;
 				}
 
@@ -439,12 +439,12 @@ class Snapshot {
 
 			if ( 1 === $args['scrub'] ) {
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
 
 				$command_esc_args = array( DB_NAME );
 
 				$command           .= ' --tables %s';
-				$command_esc_args[] = $GLOBALS['table_prefix'] . 'users';
+				$command_esc_args[] = $wpdb->users;
 
 				$mysql_args = [
 					'host'        => DB_HOST,
@@ -574,12 +574,12 @@ class Snapshot {
 					$offset += 1000;
 				}
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
 
 				$command_esc_args = array( DB_NAME );
 
 				$command           .= ' --tables %s';
-				$command_esc_args[] = $GLOBALS['table_prefix'] . 'users_temp';
+				$command_esc_args[] = $wpdb->users . '_temp';
 
 				$mysql_args = [
 					'host'        => DB_HOST,
@@ -618,12 +618,12 @@ class Snapshot {
 					$wpdb->query( "UPDATE {$wpdb->usermeta}_temp SET meta_value='{$dummy_user['first_name']}' WHERE meta_key='nickname' AND user_id='{$user_id}'" );
 				}
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
 
 				$command_esc_args = array( DB_NAME );
 
 				$command           .= ' --tables %s';
-				$command_esc_args[] = $GLOBALS['table_prefix'] . 'usermeta_temp';
+				$command_esc_args[] = $wpdb->usermeta . '_temp';
 
 				$mysql_args = [
 					'host'        => DB_HOST,

--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -395,7 +395,7 @@ class Snapshot {
 			/**
 			 * Dump sql to .wpsnapshots/data.sql
 			 */
-			$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
+			$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
 			$command_esc_args = array( DB_NAME );
 			$command         .= ' --tables';
 
@@ -439,7 +439,7 @@ class Snapshot {
 
 			if ( 1 === $args['scrub'] ) {
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
 
 				$command_esc_args = array( DB_NAME );
 
@@ -582,7 +582,7 @@ class Snapshot {
 					$offset += 1000;
 				}
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
 
 				$command_esc_args = array( DB_NAME );
 
@@ -626,7 +626,7 @@ class Snapshot {
 					$wpdb->query( "UPDATE {$wpdb->usermeta}_temp SET meta_value='{$dummy_user['first_name']}' WHERE meta_key='nickname' AND user_id='{$user_id}'" );
 				}
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
 
 				$command_esc_args = array( DB_NAME );
 

--- a/src/data/users.csv
+++ b/src/data/users.csv
@@ -70,7 +70,7 @@ gedgcumbe1w,Gib,Edgcumbe,gedgcumbe1w@cisco.com
 mbagg1x,Mildred,Bagg,mbagg1x@gizmodo.com
 amerrick1y,Aylmar,Merrick,amerrick1y@tripadvisor.com
 cstirman1z,Carole,Stirman,cstirman1z@smugmug.com
-focorr20,Freddie,O'Corr,focorr20@engadget.com
+focorr20,Freddie,O\'Corr,focorr20@engadget.com
 uiremonger21,Ula,Iremonger,uiremonger21@marriott.com
 ahuscroft22,Alfi,Huscroft,ahuscroft22@toplist.cz
 rdiscombe23,Rosette,Discombe,rdiscombe23@flavors.me
@@ -223,7 +223,7 @@ rhousaman65,Raimund,Housaman,rhousaman65@wikipedia.org
 jnapton66,Jon,Napton,jnapton66@independent.co.uk
 titzak67,Townie,Itzak,titzak67@nih.gov
 goakland68,Gabbie,Oakland,goakland68@nps.gov
-pdadda69,Pebrook,D'Adda,pdadda69@free.fr
+pdadda69,Pebrook,D\'Adda,pdadda69@free.fr
 soddie6a,Sabina,Oddie,soddie6a@jimdo.com
 dliquorish6b,Debor,Liquorish,dliquorish6b@last.fm
 cduerden6c,Culley,Duerden,cduerden6c@abc.net.au
@@ -259,7 +259,7 @@ lbrundale75,Leonid,Brundale,lbrundale75@imdb.com
 smaxwale76,Stefano,Maxwale,smaxwale76@dedecms.com
 svanelli77,Stan,Vanelli,svanelli77@sphinn.com
 ckennelly78,Christye,Kennelly,ckennelly78@friendfeed.com
-coquirk79,Claudelle,O' Quirk,coquirk79@cdbaby.com
+coquirk79,Claudelle,O\' Quirk,coquirk79@cdbaby.com
 aeverwin7a,Ailee,Everwin,aeverwin7a@ycombinator.com
 smacilriach7b,Sergei,MacIlriach,smacilriach7b@vimeo.com
 rmilmith7c,Rancell,Milmith,rmilmith7c@mit.edu
@@ -366,7 +366,7 @@ soverstonea4,Stephen,Overstone,soverstonea4@foxnews.com
 akubana5,Andrei,Kuban,akubana5@amazonaws.com
 lwissona6,Linc,Wisson,lwissona6@oakley.com
 sendsa7,Sibella,Ends,sendsa7@sourceforge.net
-foneala8,Ferrel,O'Neal,foneala8@51.la
+foneala8,Ferrel,O\'Neal,foneala8@51.la
 lnobrigaa9,Laurent,Nobriga,lnobrigaa9@arstechnica.com
 cdaillyaa,Chandal,Dailly,cdaillyaa@163.com
 qplevinab,Quillan,Plevin,qplevinab@theglobeandmail.com
@@ -425,7 +425,7 @@ bgallybr,Blakelee,Gally,bgallybr@yelp.com
 eredwallbs,Esmaria,Redwall,eredwallbs@ning.com
 miannuzzellibt,Margarete,Iannuzzelli,miannuzzellibt@apache.org
 nmussottibu,Norrie,Mussotti,nmussottibu@phoca.cz
-fdeathbv,Farris,De'Ath,fdeathbv@fema.gov
+fdeathbv,Farris,De\'Ath,fdeathbv@fema.gov
 mbownessbw,Malinda,Bowness,mbownessbw@xinhuanet.com
 pspehrbx,Petronia,Spehr,pspehrbx@edublogs.org
 fbeckensallby,Florida,Beckensall,fbeckensallby@squidoo.com
@@ -489,7 +489,7 @@ astrottondj,Alick,Strotton,astrottondj@cnet.com
 smassondk,Sam,Masson,smassondk@hatena.ne.jp
 bwhertondl,Berty,Wherton,bwhertondl@zimbio.com
 djadodm,Dunn,Jado,djadodm@sun.com
-poconcannondn,Payton,O' Concannon,poconcannondn@icq.com
+poconcannondn,Payton,O\' Concannon,poconcannondn@icq.com
 bpoytherasdo,Berti,Poytheras,bpoytherasdo@163.com
 dnenddp,Darrick,Nend,dnenddp@trellian.com
 fedisdq,Fredric,Edis,fedisdq@blog.com
@@ -554,7 +554,7 @@ bsmalefc,Bowie,Smale,bsmalefc@wunderground.com
 nsouthersfd,Nerte,Southers,nsouthersfd@google.com.au
 esunshinefe,Elysee,Sunshine,esunshinefe@networksolutions.com
 gwhifeff,Gene,Whife,gwhifeff@icio.us
-iomulderrigfg,Issie,O' Mulderrig,iomulderrigfg@cargocollective.com
+iomulderrigfg,Issie,O\' Mulderrig,iomulderrigfg@cargocollective.com
 tfirlefh,Tully,Firle,tfirlefh@delicious.com
 sbendigfi,Sapphira,Bendig,sbendigfi@archive.org
 mbothwellfj,Margarette,Bothwell,mbothwellfj@addtoany.com

--- a/src/utils.php
+++ b/src/utils.php
@@ -475,7 +475,7 @@ function get_tables( $wp = true ) {
 		$table      = $table_info[0];
 
 		if ( $wp ) {
-			if ( 0 === strpos( $table, $GLOBALS['table_prefix'] ) ) {
+			if ( 0 === strpos( $table, $wpdb->base_prefix ) ) {
 				$tables[] = $table;
 			}
 		} else {


### PR DESCRIPTION
### Description of the Change

**Multisite: User and User Meta Table Names**

This PR changes the way we are generating the `wp_users` and `wp_usermeta` table names. Instead of `$GLOBALS['table_prefix'] . 'users'` the code would use `$wpdb->users`. As `table_prefix` varies in multisite installations depending on the main blog, this seems to a safer way to identify the correct table name.

**Multisite: Table Names**

I don't know if I got an edge case but the script wasn't finding all tables, just the tables related to the main blog (that was not the original main one). Changing `$GLOBALS['table_prefix']` to `$wpdb->base_prefix` we can get all tables with the "original" prefix set in the `wp-config.php` file.

As stated in the `$wpdb` documentation [here](https://developer.wordpress.org/reference/classes/wpdb/#properties):

> $base_prefix — The original prefix as defined in wp-config.php. For multi-site: Use if you want to get the prefix without the blog number appended.

**Column Statistics**

Again, I don't know if it was a misconfiguration of my part but I ran into an `Unknown table 'COLUMN_STATISTICS' in information_schema` error. Adding `--column-statistics=0` to all `mysqldump` calls fixed the issue.

More info in this [Server Fault question](https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109).

**Tablespaces**

As per cbfa791, this PR also fixes the `mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS
privilege(s) for this operation' when trying to dump tablespaces` errors adding a `--no-tablespaces` parameter to the mysqldump calls.

**Data Escape**

As related on #64, there is a lack of escaping in the current code. Commit f7f75cd tries to fix it.

### Alternate Designs

I'm open to suggestions.

### Benefits

WP Snapshots working good with multi-sites that changed the main blog id :)

### Possible Drawbacks

n/a

### Verification Process

I've cloned the repository locally and changed it as needed to generate a snapshot for my project.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #65 and #64 

### Changelog Entry

Fixed user scrubbing on multisites.
