### PR TITLE
Remove the `--column-statistics=0 --no-tablespaces` params

### DIFF
--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -395,7 +395,7 @@ class Snapshot {
 			/**
 			 * Dump sql to .wpsnapshots/data.sql
 			 */
-			$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
+			$command          = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
 			$command_esc_args = array( DB_NAME );
 			$command         .= ' --tables';
 
@@ -439,7 +439,7 @@ class Snapshot {
 
 			if ( 1 === $args['scrub'] ) {
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
 
 				$command_esc_args = array( DB_NAME );
 
@@ -582,7 +582,7 @@ class Snapshot {
 					$offset += 1000;
 				}
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
 
 				$command_esc_args = array( DB_NAME );
 
@@ -626,7 +626,7 @@ class Snapshot {
 					$wpdb->query( "UPDATE {$wpdb->usermeta}_temp SET meta_value='{$dummy_user['first_name']}' WHERE meta_key='nickname' AND user_id='{$user_id}'" );
 				}
 
-				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction --column-statistics=0 --no-tablespaces %s';
+				$command = '/usr/bin/env mysqldump --no-defaults --single-transaction %s';
 
 				$command_esc_args = array( DB_NAME );
 


### PR DESCRIPTION
### Description of the Change

This PR reverts some of the changes introduced in #66 and is supposed to be just a hotfix, as we have an underlying issue that still needs to be solved.

The `--column-statistics=0 --no-tablespaces` parameters make sense while using newer versions of mysqldump. In WP Local Docker we are using v5.5. WP Local Docker ultimately extends debian:buster and stated [here](https://unix.stackexchange.com/a/470920) it doesn't content recent versions of mysql-client tools.

### Alternate Designs

Hopefully, we can develop a solution that conditionally adds those parameters based on the mysqldump version being used.

### Benefits

WP Snapshots working again on WP Local Docker.

### Possible Drawbacks

It generates some errors for users using it outside WP Local Docker (and with newer versions of mysqldump)

### Verification Process

It's very difficult to test this, so I'm just reverting the mysqldump calls to what they were before.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
