### PR TITLE
Updated include_files and include_db flags to accept negative values

### DIFF
--- a/src/classes/Command/Create.php
+++ b/src/classes/Command/Create.php
@@ -36,8 +36,8 @@ class Create extends Command {
 		$this->addOption( 'exclude_uploads', false, InputOption::VALUE_NONE, 'Exclude uploads from pushed snapshot.' );
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
 		$this->addOption( 'small', false, InputOption::VALUE_NONE, 'Trim data and files to create a small snapshot. Note that this action will modify your local.' );
-		$this->addOption( 'include_files', null, InputOption::VALUE_NONE, 'Include files in snapshot.' );
-		$this->addOption( 'include_db', null, InputOption::VALUE_NONE, 'Include database in snapshot.' );
+		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Include files in snapshot.', false );
+		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Include database in snapshot.', false );
 
 		$this->addOption( 'slug', null, InputOption::VALUE_REQUIRED, 'Project slug for snapshot.' );
 		$this->addOption( 'description', null, InputOption::VALUE_OPTIONAL, 'Description of snapshot.' );
@@ -105,20 +105,22 @@ class Create extends Command {
 			$exclude[] = './uploads';
 		}
 
-		if ( empty( $input->getOption( 'include_files' ) ) ) {
+		$files = $input->getOption( 'include_files' );
+		if ( false === $files ) {
 			$files_question = new ConfirmationQuestion( 'Include files in snapshot? (yes|no) ', true );
 
 			$include_files = $helper->ask( $input, $output, $files_question );
 		} else {
-			$include_files = true;
+			$include_files = is_null( $files ) || filter_var( $files, FILTER_VALIDATE_BOOLEAN ); // is_null( $files ) when `--include_files` is used without a value
 		}
 
-		if ( empty( $input->getOption( 'include_db' ) ) ) {
+		$database = $input->getOption( 'include_db' );
+		if ( false === $database ) {
 			$db_question = new ConfirmationQuestion( 'Include database in snapshot? (yes|no) ', true );
 
 			$include_db = $helper->ask( $input, $output, $db_question );
 		} else {
-			$include_db = true;
+			$include_db = is_null( $database ) || filter_var( $database, FILTER_VALIDATE_BOOLEAN ); // is_null( $database ) when `--include_db` is used without a value
 		}
 
 		if ( empty( $include_files ) && empty( $include_db ) ) {

--- a/src/classes/Command/Download.php
+++ b/src/classes/Command/Download.php
@@ -73,7 +73,7 @@ class Download extends Command {
 		if ( ! empty( $remote_meta['contains_files'] ) && ! empty( $remote_meta['contains_db'] ) ) {
 			$files = $input->getOption( 'include_files' );
 			if ( false === $files ) {
-				$files_question = new ConfirmationQuestion( 'Include files in snapshot? (Y/n) ', true );
+				$files_question = new ConfirmationQuestion( 'Do you want to download snapshot files? (Y/n) ', true );
 
 				$include_files = $helper->ask( $input, $output, $files_question );
 			} else {
@@ -82,7 +82,7 @@ class Download extends Command {
 
 			$database = $input->getOption( 'include_db' );
 			if ( false === $database ) {
-				$db_question = new ConfirmationQuestion( 'Include database in snapshot? (Y/n) ', true );
+				$db_question = new ConfirmationQuestion( 'Do you want to download the snapshot database? (Y/n) ', true );
 
 				$include_db = $helper->ask( $input, $output, $db_question );
 			} else {

--- a/src/classes/Command/Download.php
+++ b/src/classes/Command/Download.php
@@ -34,8 +34,8 @@ class Download extends Command {
 		$this->setDescription( 'Download a snapshot from the repository.' );
 		$this->addArgument( 'snapshot_id', InputArgument::REQUIRED, 'Snapshot ID to download.' );
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
-		$this->addOption( 'include_files', null, InputOption::VALUE_NONE, 'Include files in snapshot.' );
-		$this->addOption( 'include_db', null, InputOption::VALUE_NONE, 'Include database in snapshot.' );
+		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Include files in snapshot.', false );
+		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Include database in snapshot.', false );
 	}
 
 	/**
@@ -71,20 +71,22 @@ class Download extends Command {
 		$helper = $this->getHelper( 'question' );
 
 		if ( ! empty( $remote_meta['contains_files'] ) && ! empty( $remote_meta['contains_db'] ) ) {
-			if ( empty( $input->getOption( 'include_files' ) ) ) {
+			$files = $input->getOption( 'include_files' );
+			if ( false === $files ) {
 				$files_question = new ConfirmationQuestion( 'Include files in snapshot? (yes|no) ', true );
 
 				$include_files = $helper->ask( $input, $output, $files_question );
 			} else {
-				$include_files = true;
+				$include_files = is_null( $files ) || filter_var( $files, FILTER_VALIDATE_BOOLEAN ); // is_null( $files ) when `--include_files` is used without a value
 			}
 
-			if ( empty( $input->getOption( 'include_db' ) ) ) {
+			$database = $input->getOption( 'include_db' );
+			if ( false === $database ) {
 				$db_question = new ConfirmationQuestion( 'Include database in snapshot? (yes|no) ', true );
 
 				$include_db = $helper->ask( $input, $output, $db_question );
 			} else {
-				$include_db = true;
+				$include_db = is_null( $database ) || filter_var( $database, FILTER_VALIDATE_BOOLEAN ); // is_null( $database ) when `--include_db` is used without a value
 			}
 		} else {
 			$include_db    = true;
@@ -103,6 +105,7 @@ class Download extends Command {
 			}
 		}
 
+		var_dump( $include_files, $include_db );exit;
 		$snapshot = Snapshot::getRemote( $id, $repository->getName(), ! $include_files, ! $include_db );
 
 		if ( is_a( $snapshot, '\WPSnapshots\Snapshot' ) ) {

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -42,7 +42,7 @@ class Pull extends Command {
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
 		$this->addOption( 'confirm_wp_download', null, InputOption::VALUE_NONE, 'Confirm WordPress download.' );
 		$this->addOption( 'confirm_config_create', null, InputOption::VALUE_NONE, 'Confirm wp-config.php create.' );
-		$this->addOption( 'confirm_wp_version_change', null, InputOption::VALUE_NONE, 'Confirm changing WP version to match snapshot.' );
+		$this->addOption( 'confirm_wp_version_change', null, InputOption::VALUE_OPTIONAL, 'Confirm changing WP version to match snapshot.', false );
 		$this->addOption( 'confirm_ms_constant_update', null, InputOption::VALUE_NONE, 'Confirm updating constants in wp-config.php for multisite.' );
 		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Pull files within snapshot.', false );
 		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Pull database within snapshot.', false );
@@ -437,8 +437,10 @@ class Pull extends Command {
 
 				$change_wp_version = true;
 
-				if ( empty( $confirm_wp_version_change ) ) {
+				if ( false === $confirm_wp_version_change ) {
 					$change_wp_version = $helper->ask( $input, $output, new ConfirmationQuestion( 'This snapshot is running WordPress version ' . $snapshot->meta['wp_version'] . ', and you are running ' . $wp_version . '. Do you want to change your WordPress version to ' . $snapshot->meta['wp_version'] . '? (Y/n) ', true ) );
+				} else {
+					$change_wp_version = is_null( $confirm_wp_version_change ) || filter_var( $confirm_wp_version_change, FILTER_VALIDATE_BOOLEAN ); // is_null( $confirm_wp_version_change ) when `--confirm_wp_version_change` is used without a value
 				}
 
 				if ( ! empty( $change_wp_version ) ) {

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -850,8 +850,8 @@ class Pull extends Command {
 		 */
 		Log::instance()->write( 'Cleaning up temporary files...', 1 );
 
-		unlink( $snapshot_path . 'data.sql' );
-		unlink( $snapshot_path . 'wp.tar.gz' );
+		@unlink( $snapshot_path . 'data.sql' );
+		@unlink( $snapshot_path . 'wp.tar.gz' );
 
 		Log::instance()->write( 'Pull finished.', 0, 'success' );
 

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -44,8 +44,8 @@ class Pull extends Command {
 		$this->addOption( 'confirm_config_create', null, InputOption::VALUE_NONE, 'Confirm wp-config.php create.' );
 		$this->addOption( 'confirm_wp_version_change', null, InputOption::VALUE_NONE, 'Confirm changing WP version to match snapshot.' );
 		$this->addOption( 'confirm_ms_constant_update', null, InputOption::VALUE_NONE, 'Confirm updating constants in wp-config.php for multisite.' );
-		$this->addOption( 'include_files', null, InputOption::VALUE_NONE, 'Pull files within snapshot.' );
-		$this->addOption( 'include_db', null, InputOption::VALUE_NONE, 'Pull database within snapshot.' );
+		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Pull files within snapshot.', false );
+		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Pull database within snapshot.', false );
 
 		$this->addOption( 'config_db_host', null, InputOption::VALUE_REQUIRED, 'Config database host.' );
 		$this->addOption( 'config_db_name', null, InputOption::VALUE_REQUIRED, 'Config database name.' );
@@ -146,20 +146,22 @@ class Pull extends Command {
 
 		if ( $meta['contains_files'] && $meta['contains_db'] ) {
 			if ( $meta['contains_files'] ) {
-				if ( empty( $input->getOption( 'include_files' ) ) ) {
+				$files = $input->getOption( 'include_files' );
+				if ( false === $files ) {
 					$pull_files = $helper->ask( $input, $output, new ConfirmationQuestion( 'Do you want to pull files? (yes|no) ', true ) );
 				} else {
-					$pull_files = true;
+					$pull_files = is_null( $files ) || filter_var( $files, FILTER_VALIDATE_BOOLEAN ); // is_null( $files ) when `--include_files` is used without a value
 				}
 			} else {
 				$pull_files = false;
 			}
 
 			if ( $meta['contains_db'] ) {
-				if ( empty( $input->getOption( 'include_db' ) ) ) {
+				$database = $input->getOption( 'include_db' );
+				if ( false === $database ) {
 					$pull_db = $helper->ask( $input, $output, new ConfirmationQuestion( 'Do you want to pull the database? (yes|no) ', true ) );
 				} else {
-					$pull_db = true;
+					$pull_db = is_null( $database ) || filter_var( $database, FILTER_VALIDATE_BOOLEAN ); // is_null( $database ) when `--include_db` is used without a value
 				}
 			} else {
 				$pull_db = false;

--- a/src/classes/Command/Push.php
+++ b/src/classes/Command/Push.php
@@ -37,8 +37,8 @@ class Push extends Command {
 		$this->addArgument( 'snapshot_id', InputArgument::OPTIONAL, 'Optional snapshot ID to push. If none is provided, a new snapshot will be created from the local environment.' );
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
 		$this->addOption( 'small', false, InputOption::VALUE_NONE, 'Trim data and files to create a small snapshot. Note that this action will modify your local.' );
-		$this->addOption( 'include_files', null, InputOption::VALUE_NONE, 'Include files in snapshot.' );
-		$this->addOption( 'include_db', null, InputOption::VALUE_NONE, 'Include database in snapshot.' );
+		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Include files in snapshot.', false );
+		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Include database in snapshot.', false );
 
 		$this->addOption( 'slug', null, InputOption::VALUE_REQUIRED, 'Project slug for snapshot.' );
 		$this->addOption( 'description', null, InputOption::VALUE_OPTIONAL, 'Description of snapshot.' );
@@ -131,20 +131,22 @@ class Push extends Command {
 				$exclude[] = './uploads';
 			}
 
-			if ( empty( $input->getOption( 'include_files' ) ) ) {
+			$files = $input->getOption( 'include_files' );
+			if ( false === $files ) {
 				$files_question = new ConfirmationQuestion( 'Include files in snapshot? (yes|no) ', true );
 
 				$include_files = $helper->ask( $input, $output, $files_question );
 			} else {
-				$include_files = true;
+				$include_files = is_null( $files ) || filter_var( $files, FILTER_VALIDATE_BOOLEAN ); // is_null( $files ) when `--include_files` is used without a value
 			}
 
-			if ( empty( $input->getOption( 'include_db' ) ) ) {
+			$database = $input->getOption( 'include_db' );
+			if ( false === $database ) {
 				$db_question = new ConfirmationQuestion( 'Include database in snapshot? (yes|no) ', true );
 
 				$include_db = $helper->ask( $input, $output, $db_question );
 			} else {
-				$include_db = true;
+				$include_db = is_null( $database ) || filter_var( $database, FILTER_VALIDATE_BOOLEAN ); // is_null( $database ) when `--include_db` is used without a value
 			}
 
 			if ( empty( $include_files ) && empty( $include_db ) ) {


### PR DESCRIPTION
### Description of the Change

Updated `include_files` and `include_db` flags to accept negative values and allow users to control whether files or database are needed via flags. This is important for the new version of wp-local-docker which will use this flags to minimize the number of questions asked by wpsnapshots itself.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Run download command using `--include_files=yes` and `--include_db=no` flags and it will download only files.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

* Changed `--include_files` and `--include_db` flags of `create`, `download`, `pull` and `push` commands to accept negative values.
* Changed `--confirm_wp_version_change` flag of the `pull` command to accept negative values.
