### PR TITLE
Search: --format option and search for multiple queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ Documentation for each operation is as follows:
 
   After pulling, you can login as admin with the user `wpsnapshots`, password `password`.
 
-* __wpsnapshots search \<search-text\>__
+* __wpsnapshots search \<search-text\>... [--format]__
 
-  This command searches the repository for snapshots. `<search-text>` will be compared against project names and authors. Searching for "\*" will return all snapshots.
+  This command searches the repository for snapshots. `<search-text>` will be compared against project names and authors. Multiple queries can be used to search snapshots in different projects. Searching for "\*" will return all snapshots.
+
+  `--format` will render output using selected format. Supported formats are `table` and `json`. Default value is `table`.
 
 * __wpsnapshots delete \<snapshot-id\> [--verbose]__
 

--- a/bin/wpsnapshots
+++ b/bin/wpsnapshots
@@ -1,5 +1,4 @@
 #!/usr/bin/env php
-
 <?php
 
 if ( file_exists( __DIR__ . '/../vendor/autoload.php' ) ) {

--- a/src/classes/Command/Search.php
+++ b/src/classes/Command/Search.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use WPSnapshots\Utils;
 use WPSnapshots\RepositoryManager;
 use WPSnapshots\Log;
@@ -32,6 +33,7 @@ class Search extends Command {
 		$this->setDescription( 'Search for snapshots within a repository.' );
 		$this->addArgument( 'search_text', InputArgument::REQUIRED, 'Text to search against snapshots.' );
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
+		$this->addOption( 'format', null, InputOption::VALUE_OPTIONAL, 'Render output in a particular format. Available options: table and json. Defaults to table.', 'table' );
 	}
 
 	/**
@@ -61,10 +63,13 @@ class Search extends Command {
 			return;
 		}
 
-		$table = new Table( $output );
-		$table->setHeaders( [ 'ID', 'Project', 'Files', 'Database', 'Description', 'Author', 'Size', 'Multisite', 'Created' ] );
-
 		$rows = [];
+		$output_format = $input->getOption( 'format' );
+
+		$date_format = 'F j, Y, g:i a';
+		if ( 'json' === $output_format ) {
+			$date_format = 'U';
+		}
 
 		foreach ( $instances as $instance ) {
 			if ( empty( $instance['time'] ) ) {
@@ -111,15 +116,24 @@ class Search extends Command {
 				'author'         => ( ! empty( $instance['author']['name'] ) ) ? $instance['author']['name'] : '',
 				'size'           => $size,
 				'multisite'      => ( ! empty( $instance['multisite'] ) ) ? 'Yes' : 'No',
-				'created'        => ( ! empty( $instance['time'] ) ) ? date( 'F j, Y, g:i a', $instance['time'] ) : '',
+				'created'        => ( ! empty( $instance['time'] ) ) ? date( $date_format, $instance['time'] ) : '',
 			];
 		}
 
 		ksort( $rows );
 
-		$table->setRows( $rows );
-
-		$table->render();
+		switch( $output_format ) {
+			case 'json':
+				$io = new SymfonyStyle( $input, $output );
+				$io->write( json_encode( array_values( $rows ) ) . PHP_EOL );
+				break;
+			default:
+				$table = new Table( $output );
+				$table->setHeaders( [ 'ID', 'Project', 'Files', 'Database', 'Description', 'Author', 'Size', 'Multisite', 'Created' ] );
+				$table->setRows( $rows );
+				$table->render();
+				break;
+		}
 	}
 
 }

--- a/src/classes/Command/Search.php
+++ b/src/classes/Command/Search.php
@@ -31,7 +31,7 @@ class Search extends Command {
 	protected function configure() {
 		$this->setName( 'search' );
 		$this->setDescription( 'Search for snapshots within a repository.' );
-		$this->addArgument( 'search_text', InputArgument::REQUIRED, 'Text to search against snapshots.' );
+		$this->addArgument( 'search_text', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Text to search against snapshots. If multiple queries are used, they must match exactly to project names or snapshot ids.' );
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
 		$this->addOption( 'format', null, InputOption::VALUE_OPTIONAL, 'Render output in a particular format. Available options: table and json. Defaults to table.', 'table' );
 	}

--- a/src/classes/RepositoryManager.php
+++ b/src/classes/RepositoryManager.php
@@ -61,7 +61,7 @@ class RepositoryManager {
 
 		$this->repositories[ $repository_name ] = $repository;
 
-		Log::instance()->write( 'Setup repository: ' . $repository_name );
+		Log::instance()->write( 'Setup repository: ' . $repository_name, 1 );
 
 		return $repository;
 	}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Updated `search` command to allow searching using multiple queries and added `--format` option that supports `json` and `table` options. Multiple queries search is important for the new version of wp-local-docker because it will help to get information about multiple snapshots using just one command. The `--format` option is added for the same reason - to simplify integration with the new version of wp-local-docker.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Run the following command to get information about two snapshots using their ids:
```sh-session
wpsnapshots search b719bef1c09e0d2f654aa52008307a20 5639b553a97c74f54af0ecf2ae85f7a9
```
Same command but with json output:
```sh-session
wpsnapshots search b719bef1c09e0d2f654aa52008307a20 5639b553a97c74f54af0ecf2ae85f7a9 --format=json
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

* Changed the search command arguments to allow multiple queries.
* Added `--format` option to the search command that accepts `json` and `table` values.
* Fixed empty line issue rendered at the beginning of all commands.
