### PR TITLE
Suppress instructions after pull completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [2.1.0] - TBD
 
 - Added `--overwirte_local_copy` flag to the `pull` command.
+- Added `--suppress_instructions` flag to the `pull` command.
 - Added `--format` option to the search command that accepts json and table values.
 - Changed the search command arguments to allow multiple queries.
 - Changed `--include_files` and `--include_db` flags of `create`, `download`, `pull` and `push` commands to accept negative values.

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -45,6 +45,7 @@ class Pull extends Command {
 		$this->addOption( 'confirm_wp_version_change', null, InputOption::VALUE_OPTIONAL, 'Confirm changing WP version to match snapshot.', false );
 		$this->addOption( 'confirm_ms_constant_update', null, InputOption::VALUE_NONE, 'Confirm updating constants in wp-config.php for multisite.' );
 
+		$this->addOption( 'suppress_instructions', null, InputOption::VALUE_NONE, 'Suppress instructions after successful installation.' );
 		$this->addOption( 'overwrite_local_copy', null, InputOption::VALUE_NONE, 'Overwrite a local copy of the snapshot if there is one.' );
 		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Pull files within snapshot.', false );
 		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Pull database within snapshot.', false );
@@ -865,7 +866,7 @@ class Pull extends Command {
 
 		Log::instance()->write( 'Pull finished.', 0, 'success' );
 
-		if ( $pull_db ) {
+		if ( $pull_db && empty( $input->getOption( 'suppress_instructions' ) ) ) {
 			Log::instance()->write( 'Visit in your browser: ' . $first_home_url, 0, 'success' );
 
 			if ( 'localhost' !== parse_url( $first_home_url, PHP_URL_HOST ) ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Added a new flag to the pull command to suppress instructions when snapshot installation is completed. It is needed for the new version of wp-local-docker which has its own instructions.

This PR extends changes introduced in the #75. So, please, review that PR first.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
