### PR TITLE
fix: install nightly version

### DIFF
--- a/src/classes/Command/Create.php
+++ b/src/classes/Command/Create.php
@@ -49,6 +49,8 @@ class Create extends Command {
 		$this->addOption( 'db_name', null, InputOption::VALUE_REQUIRED, 'Database name.' );
 		$this->addOption( 'db_user', null, InputOption::VALUE_REQUIRED, 'Database user.' );
 		$this->addOption( 'db_password', null, InputOption::VALUE_REQUIRED, 'Database password.' );
+
+		$this->addOption( 'wp_version', null, InputOption::VALUE_OPTIONAL, 'Override the WordPress version.' );
 	}
 
 	/**
@@ -149,6 +151,7 @@ class Create extends Command {
 				'repository'     => $repository->getName(),
 				'contains_db'    => $include_db,
 				'contains_files' => $include_files,
+				'wp_version'     => $input->getOption( 'wp_version' ),
 			],
 			$output,
 			$input->getOption( 'verbose' )

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -463,7 +463,7 @@ class Pull extends Command {
 					$headers = [ 'Accept' => 'application/json' ];
 					$options = [
 						'timeout'  => 600,
-						'filename' => $snapshot_path . ( false !== stripos( $download_url, '.zip' ) ? 'wp.zip' : 'wp.tar.gz' ),
+						'filename' => $snapshot_path . ( stripos( $download_url, '.zip' ) ? 'wp.zip' : 'wp.tar.gz' ),
 					];
 
 					Log::instance()->write( 'Downloading WordPress ' . $snapshot->meta['wp_version'] . '...', 1 );
@@ -472,7 +472,7 @@ class Pull extends Command {
 
 					Log::instance()->write( 'Extracting WordPress...', 1 );
 
-					if ( false !== stripos( $download_url, '.zip' ) ) {
+					if ( stripos( $download_url, '.zip' ) ) {
 						exec( 'unzip -d ' . Utils\escape_shell_path( $path ) . ' ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.zip ' . $verbose_pipe );
 					} else {
 						exec( 'tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -463,7 +463,7 @@ class Pull extends Command {
 					$headers = [ 'Accept' => 'application/json' ];
 					$options = [
 						'timeout'  => 600,
-						'filename' => strpos( $download_url, 'zip' ) ? $snapshot_path . 'wp.zip' :$snapshot_path . 'wp.tar.gz',
+						'filename' => $snapshot_path . ( false !== stripos( $download_url, '.zip' ) ? 'wp.zip' : 'wp.tar.gz' ),
 					];
 
 					Log::instance()->write( 'Downloading WordPress ' . $snapshot->meta['wp_version'] . '...', 1 );

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -473,7 +473,13 @@ class Pull extends Command {
 					Log::instance()->write( 'Extracting WordPress...', 1 );
 
 					if ( stripos( $download_url, '.zip' ) ) {
-						exec( 'unzip -d ' . Utils\escape_shell_path( $path ) . ' ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.zip ' . $verbose_pipe );
+						$zip = new \ZipArchive;
+						if ( $zip->open( Utils\escape_shell_path( $snapshot_path ) . 'wp.zip' ) === true ) {
+							$zip->extractTo( Utils\escape_shell_path( $path ) );
+							$zip->close();
+						} else {
+							exec( 'unzip -d ' . Utils\escape_shell_path( $path ) . ' ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.zip ' . $verbose_pipe );
+						}
 					} else {
 						exec( 'tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );
 					}

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -463,7 +463,7 @@ class Pull extends Command {
 					$headers = [ 'Accept' => 'application/json' ];
 					$options = [
 						'timeout'  => 600,
-						'filename' => $snapshot_path . 'wp.tar.gz',
+						'filename' => strpos( $download_url, 'zip' ) ? $snapshot_path . 'wp.zip' :$snapshot_path . 'wp.tar.gz',
 					];
 
 					Log::instance()->write( 'Downloading WordPress ' . $snapshot->meta['wp_version'] . '...', 1 );
@@ -472,7 +472,11 @@ class Pull extends Command {
 
 					Log::instance()->write( 'Extracting WordPress...', 1 );
 
-					exec( 'tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );
+					if ( strpos( $download_url, 'zip' ) ) {
+						exec( 'unzip -d ' . Utils\escape_shell_path( $path ) . ' ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.zip ' . $verbose_pipe );
+					} else {
+						exec( 'tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );
+					}
 
 					Log::instance()->write( 'Moving WordPress files...', 1 );
 

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -472,7 +472,7 @@ class Pull extends Command {
 
 					Log::instance()->write( 'Extracting WordPress...', 1 );
 
-					if ( strpos( $download_url, 'zip' ) ) {
+					if ( false !== stripos( $download_url, '.zip' ) ) {
 						exec( 'unzip -d ' . Utils\escape_shell_path( $path ) . ' ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.zip ' . $verbose_pipe );
 					} else {
 						exec( 'tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );

--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -224,7 +224,13 @@ class Pull extends Command {
 
 			Log::instance()->write( 'Extracting WordPress...', 1 );
 
-			exec( 'rm -rf ' . Utils\escape_shell_path( $path ) . 'wordpress && tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );
+			exec( 'rm -rf ' . Utils\escape_shell_path( $path ) . 'wordpress' );
+
+			$this->extractArchive(
+				Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz',
+				Utils\escape_shell_path( $path ),
+				$verbose_pipe
+			);
 
 			Log::instance()->write( 'Moving WordPress files...', 1 );
 
@@ -460,10 +466,12 @@ class Pull extends Command {
 
 					$download_url = Utils\get_download_url( $snapshot->meta['wp_version'] );
 
+					$downloaded_file_path = Utils\escape_shell_path( $snapshot_path ) . ( strpos( $download_url, '.zip' ) ? 'wp.zip' : 'wp.tar.gz' );
+
 					$headers = [ 'Accept' => 'application/json' ];
 					$options = [
 						'timeout'  => 600,
-						'filename' => $snapshot_path . ( stripos( $download_url, '.zip' ) ? 'wp.zip' : 'wp.tar.gz' ),
+						'filename' => $downloaded_file_path,
 					];
 
 					Log::instance()->write( 'Downloading WordPress ' . $snapshot->meta['wp_version'] . '...', 1 );
@@ -472,17 +480,11 @@ class Pull extends Command {
 
 					Log::instance()->write( 'Extracting WordPress...', 1 );
 
-					if ( stripos( $download_url, '.zip' ) ) {
-						$zip = new \ZipArchive;
-						if ( $zip->open( Utils\escape_shell_path( $snapshot_path ) . 'wp.zip' ) === true ) {
-							$zip->extractTo( Utils\escape_shell_path( $path ) );
-							$zip->close();
-						} else {
-							exec( 'unzip -d ' . Utils\escape_shell_path( $path ) . ' ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.zip ' . $verbose_pipe );
-						}
-					} else {
-						exec( 'tar -C ' . Utils\escape_shell_path( $path ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'wp.tar.gz ' . $verbose_pipe );
-					}
+					$this->extractArchive(
+						$downloaded_file_path,
+						Utils\escape_shell_path( $path ),
+						$verbose_pipe
+					);
 
 					Log::instance()->write( 'Moving WordPress files...', 1 );
 
@@ -862,7 +864,11 @@ class Pull extends Command {
 
 			exec( 'mkdir -p ' . Utils\escape_shell_path( WP_CONTENT_DIR ) );
 
-			exec( 'tar -C ' . Utils\escape_shell_path( WP_CONTENT_DIR ) . ' -xf ' . Utils\escape_shell_path( $snapshot_path ) . 'files.tar.gz ' . $verbose_pipe );
+			$this->extractArchive(
+				Utils\escape_shell_path( $snapshot_path ) . 'files.tar.gz',
+				Utils\escape_shell_path( WP_CONTENT_DIR ),
+				$verbose_pipe
+			);
 		}
 
 		/**
@@ -886,4 +892,26 @@ class Pull extends Command {
 		}
 	}
 
+	/**
+	 * Extract archive file helper. Support tar and zip file
+	 *
+	 * @param string $file_path        Archive file path.
+	 * @param string $destination_path Destination path.
+	 */
+	private function extractArchive( $file_path, $destination_path, $verbose_pipe = '' ) {
+		if ( strpos( $file_path, '.tar' ) ) {
+			return exec( 'tar -C ' . $destination_path . ' -xf ' . $file_path . ' ' . $verbose_pipe );
+		}
+
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			return exec( 'unzip -d ' . $destination_path . ' ' . $file_path . ' ' . $verbose_pipe );
+		}
+
+		$zip = new \ZipArchive;
+		if ( $zip->open( $file_path ) === true ) {
+			$zip->extractTo( $destination_path );
+			$zip->close();
+		}
+	}
 }
+

--- a/src/classes/Command/Push.php
+++ b/src/classes/Command/Push.php
@@ -52,6 +52,8 @@ class Push extends Command {
 		$this->addOption( 'db_password', null, InputOption::VALUE_REQUIRED, 'Database password.' );
 		$this->addOption( 'exclude', false, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude a file or directory from the snapshot.' );
 		$this->addOption( 'exclude_uploads', false, InputOption::VALUE_NONE, 'Exclude uploads from pushed snapshot.' );
+
+		$this->addOption( 'wp_version', null, InputOption::VALUE_OPTIONAL, 'Override the WordPress version.' );
 	}
 /**
 	 * Executes the command
@@ -175,6 +177,7 @@ class Push extends Command {
 					'repository'     => $repository->getName(),
 					'contains_db'    => $include_db,
 					'contains_files' => $include_files,
+					'wp_version'     => $input->getOption( 'wp_version' ),
 				], $output, $verbose
 			);
 		}

--- a/src/classes/Snapshot.php
+++ b/src/classes/Snapshot.php
@@ -196,6 +196,9 @@ class Snapshot {
 		);
 
 		$meta['wp_version'] = ( ! empty( $wp_version ) ) ? $wp_version : '';
+		if ( ! empty( $args['wp_version'] ) ) {
+			$meta['wp_version'] = $args['wp_version'];
+		}
 
 		$author_info = RepositoryManager::instance()->getAuthorInfo();
 		$author      = [];


### PR DESCRIPTION
Currently, wpsnapshots can't install WP nightly because nightly version is available as zip file, while we only handle gz file for now. This PR fixes this issue by handling zip file for nightly version.

### Verification

#### Create latest/nightly snapshot
(_To make it clearer, please downgrade the test WP installation to one major version behind._)
1. `cd` to a WP directory, create a snapshot with the flag `--wp_version`, passing `latest` or `nightly` to create snapshot with respective WP version.
```
wpsnaphosts create --wp_version=latest
```
2. Check the meta.json file, see the version field set to the version in the step above.

#### Pull newly created snapshot.
1. `cd` to the WP directory, pull the snapshot created in the step above.
2. See the pull process successfully.
3. Check the WP version to match with the version in the step above.