### PR TITLE
Fix: Unable to skip overwriting local snapshot using one line command

### DIFF
--- a/src/classes/Command/Pull.php
+++ b/src/classes/Command/Pull.php
@@ -46,7 +46,7 @@ class Pull extends Command {
 		$this->addOption( 'confirm_ms_constant_update', null, InputOption::VALUE_NONE, 'Confirm updating constants in wp-config.php for multisite.' );
 
 		$this->addOption( 'suppress_instructions', null, InputOption::VALUE_NONE, 'Suppress instructions after successful installation.' );
-		$this->addOption( 'overwrite_local_copy', null, InputOption::VALUE_NONE, 'Overwrite a local copy of the snapshot if there is one.' );
+		$this->addOption( 'overwrite_local_copy', null, InputOption::VALUE_OPTIONAL, 'Overwrite a local copy of the snapshot if there is one.', false );
 		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Pull files within snapshot.', false );
 		$this->addOption( 'include_db', null, InputOption::VALUE_OPTIONAL, 'Pull database within snapshot.', false );
 
@@ -116,10 +116,11 @@ class Pull extends Command {
 		}
 
 		if ( ! empty( $remote_meta ) && ! empty( $local_meta ) ) {
-			if ( empty( $input->getOption( 'overwrite_local_copy' ) ) ) {
+			$overwrite_option = $input->getOption( 'overwrite_local_copy' );
+			if ( false === $overwrite_option ) {
 				$overwrite_local = $helper->ask( $input, $output, new ConfirmationQuestion( 'This snapshot exists locally. Do you want to overwrite it with the remote copy? (y/N) ', false ) );
 			} else {
-				$overwrite_local = true;
+				$overwrite_local = is_null( $overwrite_option ) || filter_var( $overwrite_option, FILTER_VALIDATE_BOOLEAN ); // is_null( $overwrite_option ) when `--overwrite_local_copy` is used without a value
 			}
 		}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR applies the approach of `--include_files` to the `--overwrite_local_copy` flag to make it skippable without prompt. 
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process
1. `cd` to a WordPress directory.
2. Pull a snapshot using `wp pull <snapshot_id>`.
3. See the prompt whether to overwrite the local snapshot.
4. `Ctrl-C` to abort the command.
5. Pull a snapshot using `wp pull <snapshot_id> --overwrite_local_copy=false`.
6. See the pull runs without overwrite local copy prompt.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #85.
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Fixed: Allow skipping --overwrite_local_copy without prompt.