### PR TITLE
Feature/exclude node modules

### DIFF
--- a/src/classes/Command/Create.php
+++ b/src/classes/Command/Create.php
@@ -110,7 +110,7 @@ class Create extends Command {
 
 		// By default exclude any node_modules folders, as they can be large and unnecessary for snapshots
 		// Can be overridden by include_node_modules option
-		if ( false === \in_array( 'node_modules', $args['exclude'], false ) && empty( $input->getOption( 'include_node_modules' ) ) ) {
+		if ( false === \in_array( 'node_modules', $exclude, false ) && empty( $input->getOption( 'include_node_modules' ) ) ) {
 			$exclude[] = '/node_modules';
 		}
 

--- a/src/classes/Command/Create.php
+++ b/src/classes/Command/Create.php
@@ -110,11 +110,7 @@ class Create extends Command {
 
 		// By default exclude any node_modules folders, as they can be large and unnecessary for snapshots
 		// Can be overridden by include_node_modules option
-		if (
-				false === \in_array( 'node_modules', $args['exclude'], false ) &&
-				empty( $args['include_node_modules'] ) &&
-				empty( $input->getOption( 'include_node_modules' ) )
-			) {
+		if ( false === \in_array( 'node_modules', $args['exclude'], false ) && empty( $input->getOption( 'include_node_modules' ) ) ) {
 			$exclude[] = '/node_modules';
 		}
 

--- a/src/classes/Command/Create.php
+++ b/src/classes/Command/Create.php
@@ -34,6 +34,7 @@ class Create extends Command {
 		$this->setDescription( 'Create a snapshot locally.' );
 		$this->addOption( 'exclude', false, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude a file or directory from the snapshot.' );
 		$this->addOption( 'exclude_uploads', false, InputOption::VALUE_NONE, 'Exclude uploads from pushed snapshot.' );
+		$this->addOption( 'include_node_modules', false, InputOption::VALUE_NONE, 'Include node_modules folder in the snapshot (excluded by default).' );
 		$this->addOption( 'repository', null, InputOption::VALUE_REQUIRED, 'Repository to use. Defaults to first repository saved in config.' );
 		$this->addOption( 'small', false, InputOption::VALUE_NONE, 'Trim data and files to create a small snapshot. Note that this action will modify your local.' );
 		$this->addOption( 'include_files', null, InputOption::VALUE_OPTIONAL, 'Include files in snapshot.', false );
@@ -105,6 +106,16 @@ class Create extends Command {
 
 		if ( ! empty( $input->getOption( 'exclude_uploads' ) ) ) {
 			$exclude[] = './uploads';
+		}
+
+		// By default exclude any node_modules folders, as they can be large and unnecessary for snapshots
+		// Can be overridden by include_node_modules option
+		if (
+				false === \in_array( 'node_modules', $args['exclude'], false ) &&
+				empty( $args['include_node_modules'] ) &&
+				empty( $input->getOption( 'include_node_modules' ) )
+			) {
+			$exclude[] = '/node_modules';
 		}
 
 		$files = $input->getOption( 'include_files' );


### PR DESCRIPTION
### Description of the Change
Introduces logic to exclude all node_modules folders by default in new snapshots with an option to include them if needed.

### Benefits
Will result in smaller snapshot sizes and faster installs

### Possible Drawbacks
Users will need to run 'npm install' on their local machines when they need to build files. This doesn't seem to be too big of an issue, as the packages are likely out of date and would need a pull from the repo and reinstall in any case.

### Verification Process
- Ran original `wpsnapshots create` command without any changes and noted the size of the snapshot zip file (178.8MB)
- Made changes and ran `wpsnapshots create` command and noted the size of the snapshot zip file (131.6MB)
- Checked zip to ensure node_modules folders are not included
- Ran `wpsnapshots create --include_node_modules` and verified the zip was created with the node_modules folders.

![Screen Shot 2021-06-25 at 4 18 08 PM](https://user-images.githubusercontent.com/7133400/123481537-deeeb880-d5d1-11eb-8433-a2501dd43de9.png)

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
