### PR TITLE
Update Docker image to a PHP8 version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
       #     key: ${{ runner.os }}-buildx-${{ github.sha }}
       #     restore-keys: |
       #       ${{ runner.os }}-buildx-
-      - uses: docker/login-action@v1 
+      - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -60,6 +60,7 @@ jobs:
           context: ./docker
           file: ./docker/Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             WPSNAPSHOTS_ARCHIVE=${{ steps.prep.outputs.archive }}
           labels: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,34 @@
-FROM 10up/phpfpm
+FROM 10up/wp-php-fpm-dev:8.0-ubuntu AS builder
 
 ARG WPSNAPSHOTS_ARCHIVE
 ENV WPSNAPSHOTS_ARCHIVE $WPSNAPSHOTS_ARCHIVE
 
+USER root
+
 WORKDIR /opt/wpsnapshots
 
-RUN useradd wpsnapshots && \
-    mkdir -p /home/wpsnapshots && \
-    chown -R wpsnapshots:wpsnapshots /home/wpsnapshots && \
-    wget -q -c ${WPSNAPSHOTS_ARCHIVE} -O - | tar -xz --strip 1 && \
-    composer install --no-dev --no-progress && \
-    composer clear-cache && \
-    chown -R wpsnapshots:wpsnapshots /opt/wpsnapshots
+RUN \
+  useradd wpsnapshots && \
+  mkdir -p /home/wpsnapshots && \
+  chown -R wpsnapshots:wpsnapshots /home/wpsnapshots && \
+  wget -q -c ${WPSNAPSHOTS_ARCHIVE} -O - | tar -xz --strip 1 && \
+  composer install --no-dev --no-progress && \
+  composer clear-cache && \
+  chown -R wpsnapshots:wpsnapshots /opt/wpsnapshots
 
+FROM 10up/base-php:7.4-ubuntu
+
+USER root
+
+WORKDIR /opt/wpsnapshots
+
+COPY --from=builder --chown=wpsnapshots=wpsnapshots /opt/wpsnapshots /opt/wpsnapshots
+RUN \
+  apt-get update && apt-get install mariadb-client -y && apt-get clean all && \
+  useradd wpsnapshots && \
+  mkdir -p /home/wpsnapshots && \
+  chown -R wpsnapshots:wpsnapshots /home/wpsnapshots && \
+  chown -R wpsnapshots:wpsnapshots /opt/wpsnapshots
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
### Description of the Change
Very few projects are now using < PHP 8, and there are issues with the current snapshots pushing PHP 8 code, since the docker image is running PHP 7.3.9.

This updates the docker image to use PHP8 and adds support for ARM processors. See the notes by @dustinrue in #92, which this builds upon.

This PR modifies the Dockerfile and build routines (actions) to:

* Build the image off of the updated upstream image ~~`10up/wp-php-fpm-dev:7.4-ubuntu`~~ `10up/wp-php-fpm-dev:8.0-ubuntu`
* Provide a multi-stage build to reduce overall image size (using ~~`10up/base-php:7.4-ubuntu`~~ `10up/base-php:8.0-ubuntu`)
* Updates the Github action to build for both amd64 and arm64 (adding native, full speed support for Apple's M series of processor including M1)
 
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #94 #83 #92 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
* Update base image and create multi-arch image compatible with arm64 and Apple M series processors


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dustinrue @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
